### PR TITLE
Make some more elements optional

### DIFF
--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -136,14 +136,29 @@ pub enum DeviceProperty {
     Slots {
         // TODO
     },
+    Su {
+        // TODO
+    },
+    AlternativeType {
+        // TODO
+    },
+    VendorSpecific {
+        // TODO
+    },
+    SubDevice {
+        // TODO
+    },
+    ESC {
+        // TODO
+    },
 }
 
 #[allow(non_snake_case)]
 #[derive(Debug, Deserialize, PartialEq)]
 pub struct DeviceType {
     ModulePdoGroup: Option<String>,
-    ProductCode: String,
-    RevisionNo: String,
+    ProductCode: Option<String>,
+    RevisionNo: Option<String>,
     #[serde(rename = "$value")]
     Description: String,
 }
@@ -153,8 +168,9 @@ pub struct DeviceType {
 pub struct Sm {
     Enable: Option<u8>,
     StartAddress: String,
-    ControlByte: String,
+    ControlByte: Option<String>,
     DefaultSize: Option<String>,
+    Virtual: Option<String>,
 }
 
 #[allow(non_snake_case)]
@@ -173,12 +189,12 @@ pub type TxPdo = Pdo;
 #[allow(non_snake_case)]
 #[derive(Debug, Clone, Deserialize, PartialEq)]
 pub struct Pdo {
-    Sm: u8,
+    Sm: Option<u8>,
     Fixed: Option<String>,
     Mandatory: Option<String>,
     Index: Index,
     Name: Option<String>,
-    Entry: Vec<Entry>,
+    Entry: Option<Vec<Entry>>,
 }
 
 #[allow(non_snake_case)]
@@ -194,10 +210,10 @@ pub struct Index {
 pub struct Module {
     Type: String,
     Name: Option<String>,
-    TxPdo: Option<Pdo>,
-    RxPdo: Option<Pdo>,
-    Mailbox: Mailbox,
-    Profile: Profile,
+    TxPdo: Option<Vec<TxPdo>>,
+    RxPdo: Option<Vec<RxPdo>>,
+    Mailbox: Option<Mailbox>,
+    Profile: Option<Profile>,
 }
 
 #[allow(non_snake_case)]
@@ -401,7 +417,7 @@ mod tests {
         assert_eq!(
             pdo,
             RxPdo {
-                Sm: 2,
+                Sm: Some(2),
                 Fixed: Some("1".to_string()),
                 Mandatory: Some("true".to_string()),
                 Index: Index {
@@ -409,7 +425,7 @@ mod tests {
                     value: "#x16ff".to_string(),
                 },
                 Name: Some("".to_string()),
-                Entry: vec![Entry {
+                Entry: Some(vec![Entry {
                     Index: Index {
                         DependOnSlot: None,
                         value: "#xf200".to_string(),
@@ -418,7 +434,7 @@ mod tests {
                     BitLen: 1,
                     Name: Some("".to_string()),
                     DataType: Some("BOOL".to_string()),
-                }]
+                }])
             }
         );
     }
@@ -429,10 +445,10 @@ mod tests {
         <Device>
           <Type ProductCode="#x45" RevisionNo="#x001">Foo</Type>
           <Name>Bar</Name>
-          <Sm Enable="1" StartAddress="#x1000" ControlByte="#x26" DefaultSize="512" />
-          <Sm Enable="1" StartAddress="#x1400" ControlByte="#x22" DefaultSize="#x200" />
-          <Sm            StartAddress="#x1800" ControlByte="#x64"                 />
-          <Sm Enable="0" StartAddress="#x2400" ControlByte="#x20" DefaultSize="0" />
+          <Sm Enable="1" StartAddress="#x1000" ControlByte="#x26" DefaultSize="512"   Virtual="1" />
+          <Sm Enable="1" StartAddress="#x1400" ControlByte="#x22" DefaultSize="#x200" Virtual="0" />
+          <Sm            StartAddress="#x1800" ControlByte="#x64"                     Virtual="true" />
+          <Sm Enable="0" StartAddress="#x2400"                    DefaultSize="0" />
         </Device>"##;
         let device: Device = from_str(s).unwrap();
         assert_eq!(
@@ -443,8 +459,8 @@ mod tests {
                     DeviceProperty::Type(DeviceType {
                         Description: "Foo".to_string(),
                         ModulePdoGroup: None,
-                        ProductCode: "#x45".to_string(),
-                        RevisionNo: "#x001".to_string(),
+                        ProductCode: Some("#x45".to_string()),
+                        RevisionNo: Some("#x001".to_string()),
                     }),
                     DeviceProperty::Name(Name {
                         LcId: None,
@@ -454,26 +470,30 @@ mod tests {
                         Sm {
                             Enable: Some(1),
                             StartAddress: "#x1000".to_string(),
-                            ControlByte: "#x26".to_string(),
+                            ControlByte: Some("#x26".to_string()),
                             DefaultSize: Some("512".to_string()),
+                            Virtual: Some("1".to_string()),
                         },
                         Sm {
                             Enable: Some(1),
                             StartAddress: "#x1400".to_string(),
-                            ControlByte: "#x22".to_string(),
+                            ControlByte: Some("#x22".to_string()),
                             DefaultSize: Some("#x200".to_string()),
+                            Virtual: Some("0".to_string()),
                         },
                         Sm {
                             Enable: None,
                             StartAddress: "#x1800".to_string(),
-                            ControlByte: "#x64".to_string(),
+                            ControlByte: Some("#x64".to_string()),
                             DefaultSize: None,
+                            Virtual: Some("true".to_string()),
                         },
                         Sm {
                             Enable: Some(0),
                             StartAddress: "#x2400".to_string(),
-                            ControlByte: "#x20".to_string(),
+                            ControlByte: None,
                             DefaultSize: Some("0".to_string()),
+                            Virtual: None,
                         }
                     ]),
                 ]

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -14,12 +14,15 @@ pub struct EtherCatInfo {
 pub struct Vendor {
     pub file_version: Option<u32>,
     pub id: u32,
-    pub name: Option<String>,
+    pub name: Names,
     pub comment: Option<String>,
     pub url: Option<String>,
     pub desc_url: Option<String>,
     pub image: Option<Image>,
 }
+
+/// A collection of human readable names, with attached language IDs.
+pub type Names = Vec<(String, Option<u16>)>;
 
 /// Further slave descriptions.
 #[derive(Debug, Clone, Default)]
@@ -43,7 +46,7 @@ pub struct Group {
     pub sort_order: Option<i32>,
     pub parent_group: Option<String>,
     pub r#type: String,
-    pub name: String,
+    pub name: Names,
     pub comment: Option<String>,
     pub image: Option<Image>,
     // TODO: Optional 'VendorSpecific'
@@ -52,7 +55,7 @@ pub struct Group {
 #[derive(Debug, Clone)]
 pub struct Device {
     pub physics: Option<String>,
-    pub name: String,
+    pub name: Names,
     pub desc: String,
     pub product_code: Option<u32>,
     pub revision_no: Option<u32>,
@@ -78,7 +81,7 @@ pub struct Pdo {
     pub fixed: bool,
     pub mandatory: bool,
     pub idx: PdoIdx,
-    pub name: Option<String>,
+    pub name: Names,
     pub entries: Vec<PdoEntry>,
 }
 
@@ -93,14 +96,14 @@ pub struct Sdo {
 pub struct PdoEntry {
     pub entry_idx: PdoEntryIdx,
     pub bit_len: usize,
-    pub name: Option<String>,
+    pub name: Names,
     pub data_type: Option<String>,
 }
 
 #[derive(Debug, Clone)]
 pub struct Module {
     pub r#type: String,
-    pub name: Option<String>,
+    pub name: Names,
     pub tx_pdo: Vec<Pdo>,
     pub rx_pdo: Vec<Pdo>,
     pub mailbox: Option<Mailbox>,

--- a/src/structs.rs
+++ b/src/structs.rs
@@ -54,8 +54,8 @@ pub struct Device {
     pub physics: Option<String>,
     pub name: String,
     pub desc: String,
-    pub product_code: u32,
-    pub revision_no: u32,
+    pub product_code: Option<u32>,
+    pub revision_no: Option<u32>,
     pub sm: Vec<Sm>,
     pub rx_pdo: Vec<Pdo>,
     pub tx_pdo: Vec<Pdo>,
@@ -66,14 +66,15 @@ pub struct Device {
 pub struct Sm {
     pub enable: bool,
     pub start_address: u16,
-    pub control_byte: u8,
+    pub control_byte: Option<u8>,
     pub default_size: Option<usize>,
+    pub r#virtual: bool,
 }
 
 /// Process Data Object (PDO).
 #[derive(Debug, Clone)]
 pub struct Pdo {
-    pub sm: SmIdx,
+    pub sm: Option<SmIdx>,
     pub fixed: bool,
     pub mandatory: bool,
     pub idx: PdoIdx,
@@ -100,10 +101,10 @@ pub struct PdoEntry {
 pub struct Module {
     pub r#type: String,
     pub name: Option<String>,
-    pub tx_pdo: Option<Pdo>,
-    pub rx_pdo: Option<Pdo>,
-    pub mailbox: Mailbox,
-    pub profile: Profile,
+    pub tx_pdo: Vec<Pdo>,
+    pub rx_pdo: Vec<Pdo>,
+    pub mailbox: Option<Mailbox>,
+    pub profile: Option<Profile>,
 }
 
 #[derive(Debug, Clone)]

--- a/tests/parse-xml.rs
+++ b/tests/parse-xml.rs
@@ -12,12 +12,12 @@ fn parse_xml_crated_by_weidmueller() {
     assert_eq!(esi.description.devices.len(), 2);
     let dev_0 = &esi.description.devices[0];
     let dev_1 = &esi.description.devices[1];
-    assert_eq!(dev_0.product_code, 0x4F911C30);
-    assert_eq!(dev_1.product_code, 0x4F911C30);
-    assert_eq!(dev_0.revision_no, 0x1);
-    assert_eq!(dev_1.revision_no, 0x00011100);
+    assert_eq!(dev_0.product_code, Some(0x4F911C30));
+    assert_eq!(dev_1.product_code, Some(0x4F911C30));
+    assert_eq!(dev_0.revision_no, Some(0x1));
+    assert_eq!(dev_1.revision_no, Some(0x00011100));
     assert_eq!(dev_0.sm[0].start_address, 0x1000);
-    assert_eq!(dev_0.sm[0].control_byte, 0x26);
+    assert_eq!(dev_0.sm[0].control_byte, Some(0x26));
     assert_eq!(dev_0.rx_pdo[0].idx, ec::PdoIdx::from(0x16FF));
     assert_eq!(
         dev_0.rx_pdo[0].entries[0].entry_idx.idx,
@@ -38,7 +38,7 @@ fn parse_xml_crated_by_weidmueller_module_information() {
     assert_eq!(esi.vendor.id, 0x0000_0230);
     assert_eq!(esi.description.modules.len(), 82);
     let m = &esi.description.modules[0];
-    assert_eq!(m.tx_pdo.as_ref().unwrap().entries.len(), 6);
+    assert_eq!(m.tx_pdo[0].entries.len(), 6);
 }
 
 #[test]


### PR DESCRIPTION
This allows successfully parsing all the EtherCATInfo files from the Beckhoff ESI package.